### PR TITLE
Fix(site): Headbar Link

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
     <header class="bg-white/80 backdrop-blur-lg sticky top-0 z-50 shadow-sm">
         <nav class="container mx-auto px-4">
             <div class="flex justify-between items-center py-4">
-                <a href="/" class="flex items-center space-x-2">
+                <a href="/setting-bind-dns" class="flex items-center space-x-2">
                     <img src="assets/favicon/favicon-96x96.png" alt="Logo BIND"
                         style="width: 32px; height: 32px; vertical-align: middle;">
                     <div class="text-2xl font-bold text-gray-900">


### PR DESCRIPTION
[Isso foi gerado pelo Copilot]

Este pull request inclui uma pequena alteração no link de navegação no cabeçalho do site. O link do logotipo no cabeçalho agora aponta para `/setting-bind-dns` em vez da página inicial.

([index.htmlL28-R28](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L28-R28))